### PR TITLE
Napraw separatory w storybooku i wyciągnij typy do osobnych plików

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_size = 4
 
 [{package.json,package-lock.json}]
 indent_size = 2
+
+[.storybook/preview.tsx]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -67,6 +67,7 @@ Makefile          text
 makefile          text
 # Fixes syntax highlighting on GitHub to allow comments
 tsconfig.json     linguist-language=JSON-with-Comments
+.storybook/preview.tsx  text eol=crlf
 
 # Graphics
 *.ai              binary

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,6 @@ import type { StorybookConfig } from '@storybook/react-vite';
 const config: StorybookConfig = {
     stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
     addons: [
-        '@storybook/addon-onboarding',
         '@storybook/addon-links',
         '@storybook/addon-essentials',
         '@storybook/addon-interactions',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@storybook/addon-essentials": "^8.6.2",
         "@storybook/addon-interactions": "^8.6.2",
         "@storybook/addon-links": "^8.6.2",
-        "@storybook/addon-onboarding": "^8.6.2",
         "@storybook/blocks": "^8.6.2",
         "@storybook/manager-api": "^8.6.2",
         "@storybook/react": "^8.6.2",
@@ -2010,20 +2009,6 @@
         "@storybook/global": "^5.0.0",
         "tiny-invariant": "^1.3.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.2"
-      }
-    },
-    "node_modules/@storybook/addon-onboarding": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-onboarding/-/addon-onboarding-8.6.2.tgz",
-      "integrity": "sha512-uPmh79wsyU5LNO6NGA0bcQBwGQsuY1CcihJX96vY32/JwKijQoiayxOdljTJdFzd4rLkDzoGu5q4WdAd6gTbRg==",
-      "dev": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@storybook/addon-essentials": "^8.6.2",
     "@storybook/addon-interactions": "^8.6.2",
     "@storybook/addon-links": "^8.6.2",
-    "@storybook/addon-onboarding": "^8.6.2",
     "@storybook/blocks": "^8.6.2",
     "@storybook/manager-api": "^8.6.2",
     "@storybook/react": "^8.6.2",

--- a/src/main.style.tsx
+++ b/src/main.style.tsx
@@ -24,6 +24,10 @@ const CommonGlobalStyle = createGlobalStyle`
         font-family: 'Inter', sans-serif;
         margin: 0;
     }
+
+    input:focus, a:focus, button:focus {
+        outline: 2px solid ${(props) => props.theme.colors.highlight};
+    }
 `;
 
 const DarkGlobalStyle = createGlobalStyle`

--- a/src/shared/components/H/H.stories.tsx
+++ b/src/shared/components/H/H.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import H from '@/shared/components/H';
 
-// noinspection JSUnusedGlobalSymbols
 export default {
     title: 'Shared/Components/H',
     component: H,
@@ -13,7 +12,6 @@ export default {
     ),
 } satisfies Meta<typeof H>;
 
-// noinspection JSUnusedGlobalSymbols
 export const Default: StoryObj<typeof H> = {
     args: {
         level: 1,

--- a/src/shared/components/H/H.style.tsx
+++ b/src/shared/components/H/H.style.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
 
-import { HeadingLevel } from '@/shared/components/H/H';
+import { HeadingLevel } from '@/shared/components/H/types';
 import {
     fontSizes,
     lineHeights,
     fontWeights,
-    sizes,
 } from '@/shared/constants/dimensions';
 
 export const StyledH = styled.p<{
@@ -14,8 +13,7 @@ export const StyledH = styled.p<{
     $secondary?: boolean;
 }>`
     font-size: ${(props) => Object.values(fontSizes)[props.$level - 1]};
-    line-height: ${lineHeights.small};
-    margin: ${sizes.smallXL} 0;
+    line-height: ${(props) => Object.values(lineHeights)[props.$level - 1]};
     font-weight: ${(props) =>
         props.$bold ? fontWeights.bold : fontWeights.regular};
     color: ${(props) =>

--- a/src/shared/components/H/H.tsx
+++ b/src/shared/components/H/H.tsx
@@ -1,13 +1,5 @@
 import { StyledH } from '@/shared/components/H/H.style';
-import { PProps } from '@/shared/components/P/P';
-
-export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
-export interface HProps extends PProps {
-    /**
-     * Level of the heading, reflects the HTML \<h1\>, \<h2\>... etc. tags numeration
-     */
-    level: HeadingLevel;
-}
+import { HProps } from '@/shared/components/H/types';
 
 /**
  * A UI component which renders a styled heading

--- a/src/shared/components/H/types.ts
+++ b/src/shared/components/H/types.ts
@@ -1,0 +1,10 @@
+import { PProps } from '@/shared/components/P/types';
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface HProps extends PProps {
+    /**
+     * Level of the heading, reflects the HTML \<h1\>, \<h2\>... etc. tags numeration
+     */
+    level: HeadingLevel;
+}

--- a/src/shared/components/P/P.stories.tsx
+++ b/src/shared/components/P/P.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import P from '@/shared/components/P';
 
-// noinspection JSUnusedGlobalSymbols
 export default {
     title: 'Shared/Components/P',
     component: P,
@@ -13,7 +12,6 @@ export default {
     ),
 } satisfies Meta<typeof P>;
 
-// noinspection JSUnusedGlobalSymbols
 export const Default: StoryObj<typeof P> = {
     args: {
         bold: false,

--- a/src/shared/components/P/P.style.tsx
+++ b/src/shared/components/P/P.style.tsx
@@ -4,13 +4,11 @@ import {
     fontSizes,
     lineHeights,
     fontWeights,
-    sizes,
 } from '@/shared/constants/dimensions';
 
 export const StyledP = styled.p<{ $bold?: boolean; $secondary?: boolean }>`
     font-size: ${fontSizes.small};
     line-height: ${lineHeights.small};
-    margin: ${sizes.smallXL} 0;
     font-weight: ${(props) =>
         props.$bold ? fontWeights.bold : fontWeights.regular};
     color: ${(props) =>

--- a/src/shared/components/P/P.tsx
+++ b/src/shared/components/P/P.tsx
@@ -1,17 +1,5 @@
-import React from 'react';
-
-import { StyledP } from '@/shared/components/P/P.style.tsx';
-
-export interface PProps extends React.ComponentProps<typeof StyledP> {
-    /**
-     * If the text should appear bold
-     */
-    bold?: boolean;
-    /**
-     * If the text should be a secondary color
-     */
-    secondary?: boolean;
-}
+import { StyledP } from '@/shared/components/P/P.style';
+import { PProps } from '@/shared/components/P/types';
 
 /**
  * A UI component which renders a styled paragraph

--- a/src/shared/components/P/types.ts
+++ b/src/shared/components/P/types.ts
@@ -1,0 +1,14 @@
+import { ComponentProps } from 'react';
+
+import { StyledP } from '@/shared/components/P/P.style';
+
+export interface PProps extends ComponentProps<typeof StyledP> {
+    /**
+     * If the text should appear bold
+     */
+    bold?: boolean;
+    /**
+     * If the text should be a secondary color
+     */
+    secondary?: boolean;
+}

--- a/src/shared/components/Text/Text.stories.tsx
+++ b/src/shared/components/Text/Text.stories.tsx
@@ -2,23 +2,19 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import Text from '@/shared/components/Text';
 
-// noinspection JSUnusedGlobalSymbols
 export default {
     title: 'Shared/Components/Text',
     component: Text,
 } satisfies Meta<typeof Text>;
 
-// noinspection JSUnusedGlobalSymbols
 export const Default: StoryObj<typeof Text> = {};
 
-// noinspection JSUnusedGlobalSymbols
 export const WithLabel: StoryObj<typeof Text> = {
     args: {
         label: 'Input label',
     },
 };
 
-// noinspection JSUnusedGlobalSymbols
 export const WithError: StoryObj<typeof Text> = {
     args: {
         label: 'Input label',

--- a/src/shared/components/Text/Text.style.tsx
+++ b/src/shared/components/Text/Text.style.tsx
@@ -3,25 +3,20 @@ import styled from 'styled-components';
 import { fontSizes, lineHeights, sizes } from '@/shared/constants/dimensions';
 
 export const StyledInput = styled.input<{ $error?: boolean }>`
-    & {
-        font-size: ${fontSizes.small};
-        line-height: ${lineHeights.small};
-        padding: ${sizes.smallXL};
-        border: none;
-        border-radius: ${sizes.smallXL};
-        width: 300px;
-        color: ${(props) => props.theme.colors.secondaryText};
-        background-color: ${(props) => props.theme.colors.primaryAccent};
-        outline: 1px solid ${(props) => props.theme.colors.primaryText};
-        ${(props) =>
-            props.$error
-                ? `outline: 2px solid ${props.theme.colors.error};
+    font-size: ${fontSizes.small};
+    line-height: ${lineHeights.small};
+    padding: ${sizes.smallXL};
+    border: none;
+    border-radius: ${sizes.smallXL};
+    width: 300px;
+    color: ${(props) => props.theme.colors.secondaryText};
+    background-color: ${(props) => props.theme.colors.primaryAccent};
+    outline: 1px solid ${(props) => props.theme.colors.primaryText};
+    ${(props) =>
+        props.$error
+            ? `outline: 2px solid ${props.theme.colors.error};
                    color: ${props.theme.colors.error};`
-                : ''};
-    }
-    &:focus {
-        outline: 2px solid ${(props) => props.theme.colors.highlight};
-    }
+            : ''};
 `;
 
 export const StyledLabel = styled.p`

--- a/src/shared/components/Text/Text.tsx
+++ b/src/shared/components/Text/Text.tsx
@@ -1,27 +1,11 @@
-import React, { useId } from 'react';
+import { useId } from 'react';
 
 import {
     StyledDescription,
     StyledInput,
     StyledLabel,
 } from '@/shared/components/Text/Text.style';
-
-export type TextTypes = 'text' | 'password' | 'email';
-
-export interface TextProps extends React.ComponentProps<typeof StyledInput> {
-    /**
-     * What type of value the input expects
-     */
-    type?: TextTypes;
-    /**
-     * Optional label placed above the input
-     */
-    label?: string;
-    /**
-     * Optional error message underneath the field, also highlights the input
-     */
-    error?: string;
-}
+import { TextProps } from '@/shared/components/Text/types';
 
 /**
  * A UI component which accepts user text input

--- a/src/shared/components/Text/types.ts
+++ b/src/shared/components/Text/types.ts
@@ -1,0 +1,20 @@
+import { ComponentProps } from 'react';
+
+import { StyledInput } from '@/shared/components/Text/Text.style';
+
+export type TextTypes = 'text' | 'password' | 'email';
+
+export interface TextProps extends ComponentProps<typeof StyledInput> {
+    /**
+     * What type of value the input expects
+     */
+    type?: TextTypes;
+    /**
+     * Optional label placed above the input
+     */
+    label?: string;
+    /**
+     * Optional error message underneath the field, also highlights the input
+     */
+    error?: string;
+}


### PR DESCRIPTION
- Naprawiłem separatory w storybooku
- Wyciągnąłem style które dotyczyły focus'a
- Wywaliłem komentarze wyłączające linter w stories
- Wyciągnąłem wszystkie interfejsy i typy do osobnych plików